### PR TITLE
span-test: gcc support

### DIFF
--- a/src/span-test.cpp
+++ b/src/span-test.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <print>
 #include <string>
 


### PR DESCRIPTION
std::memcmp requires cstring